### PR TITLE
require new Win32::TieRegistry on perl 5.20 - changes in this version of...

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -31,7 +31,11 @@ my %config_prereq = (
 
 my %IsWin32 = map { $_ => 1 } qw( MSWin32 NetWare symbian );
 my $IsWin32 = 1   if ($IsWin32{ $^O });
-if (! $IsWin32) {
+if ($IsWin32) {
+   if ($^V >= 5.020) {
+      $module_prereq{'Win32::TieRegistry'} = 0.28;
+   }
+} else {
    delete $module_prereq{'Win32::TieRegistry'};
 }
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,11 @@ my %config_prereq = (
 
 my %IsWin32 = map { $_ => 1 } qw( MSWin32 NetWare symbian );
 my $IsWin32 = 1   if ($IsWin32{ $^O });
-if (! $IsWin32) {
+if ($IsWin32) {
+   if ($^V >= 5.020) {
+      $module_prereq{'Win32::TieRegistry'} = 0.28;
+   }
+} else {
    delete $module_prereq{'Win32::TieRegistry'};
 }
 


### PR DESCRIPTION
... perl broke Win32::TieRegistry
