### PR TITLE
Fix determining TZ from /etc/localtime

### DIFF
--- a/lib/Date/Manip/TZ.pm
+++ b/lib/Date/Manip/TZ.pm
@@ -571,6 +571,8 @@ sub _get_curr_zone {
          my $file    = shift(@methods);
          my $dir     = shift(@methods);
 
+         print "$file $dir" if ($debug);
+
          my $z;
          if (-f $file  &&  -d $dir) {
             $z = _get_zoneinfo_zone($file,$dir);
@@ -717,7 +719,7 @@ sub _get_curr_zone {
       if (-l $localtime) {
          return _zoneinfo_file_name_to_zone(
                                             Cwd::abs_path($localtime),
-                                            $zoneinfo,
+                                            Cwd::abs_path($zoneinfo),
                                            );
       }
 


### PR DESCRIPTION
Fix determining TZ from /etc/localtime symlink when $zoneinfo dir itself is also a symlink

This is required on MacOS X High Sierra