### PR TITLE
TZ.pm/_init: fall back to `/usr/bin/env -i` in TZ detection

### DIFF
--- a/lib/Date/Manip/TZ.pm
+++ b/lib/Date/Manip/TZ.pm
@@ -110,6 +110,7 @@ sub _init {
                                    'command',  '/bin/date +%Z',
                                    'command',  '/usr/bin/date +%Z',
                                    'command',  '/usr/local/bin/date +%Z',
+                                   'command',  '/usr/bin/env -i -- date +%Z',
                                    qw(cmdfield /bin/date -2
                                       cmdfield /usr/bin/date -2
                                       cmdfield /usr/local/bin/date -2
@@ -117,6 +118,7 @@ sub _init {
                                    'command',  '/bin/date +%z',
                                    'command',  '/usr/bin/date +%z',
                                    'command',  '/usr/local/bin/date +%z',
+                                   'command', '/usr/bin/env -i -- date +%z',
                                    'gmtoff'
                                   ];
 


### PR DESCRIPTION
Falls back to a non-clobbered PATH using env -i when calling path. This fixes
problem detecting time zone in NixOS.

This fixes #25 