### PR TITLE
[Patch] TZ.pm: Check also the Alias hash from Zones.pm for the zone verification.

### DIFF
--- a/lib/Date/Manip/TZ.pm
+++ b/lib/Date/Manip/TZ.pm
@@ -762,7 +762,8 @@ sub _zoneinfo_file_name_to_zone {
    my($file,$zoneinfo) = @_;
    require File::Spec;
    my $zone = File::Spec->abs2rel($file,$zoneinfo);
-   return $zone  if (exists $Date::Manip::Zones::ZoneNames{lc($zone)});
+   return $zone  if (exists $Date::Manip::Zones::ZoneNames{lc($zone)} ||
+                     exists $Date::Manip::Zones::Alias{lc($zone)});
    return;
 }
 


### PR DESCRIPTION
If a Linux system has been configured with a time zone alias, the latest version of `Date::Manip` throws an error and falls back to use the GMT time zone.

This patch fixes the `_zoneinfo_file_name_to_zone` routine defined in `TZ.pm` to check both `$Date::Manip::Zones::ZoneNames` and `$Date::Manip::Zones::Alias` hashes when verifying the `$zone`.

Please see the following for a demonstration of the behavior, first with the current version and then with the patched one.

The upstream version works as expected when the non-alias format is used:
~~~
# git checkout master
# sudo timedatectl set-timezone America/Argentina/Buenos_Aires  # Non-alias TZ
# perl -MDate::Manip -le 'print("System local time (set to ".Date_TimeZone.") with perl(Date::Manip) version ".$Date::Manip::VERSION.": ".UnixDate("now","%Y-%m-%d %H:%M:%S %Z"));'
System local time (set to america/argentina/buenos_aires) with perl(Date::Manip) version 6.91: 2023-02-23 14:16:13 -03
~~~

However, when using the alias format, it throws an error and falls back to GMT:
~~~
# sudo timedatectl set-timezone America/Buenos_Aires  # TZ alias
# perl -MDate::Manip -le 'print("System local time (set to ".Date_TimeZone.") with perl(Date::Manip) version ".$Date::Manip::VERSION.": ".UnixDate("now","%Y-%m-%d %H:%M:%S %Z"));'
ERROR: Date::Manip unable to determine Time Zone.  GMT will be used. at /home/wyrmiyu/git/Date-Manip/perllib/lib/perl5/Date/Manip/DM6.pm line 65.
ERROR: Date::Manip unable to determine Time Zone.  GMT will be used. at /home/wyrmiyu/git/Date-Manip/perllib/lib/perl5/Date/Manip/DM6.pm line 68.
System local time (set to etc/gmt) with perl(Date::Manip) version 6.91: 2023-02-23 14:16:58 GMT
~~~

The patched version works as expected when using the non-alias format:
~~~
# git checkout fix_zoneinfo_file_name_to_zone
# sudo timedatectl set-timezone America/Argentina/Buenos_Aires  # Non-alias TZ
# perl -MDate::Manip -le 'print("System local time (set to ".Date_TimeZone.") with perl(Date::Manip) version ".$Date::Manip::VERSION.": ".UnixDate("now","%Y-%m-%d %H:%M:%S %Z"));'
System local time (set to america/argentina/buenos_aires) with perl(Date::Manip) version 6.91: 2023-02-23 14:16:13 -03
~~~

With this patch, the TZ alias also works as expected:
~~~
# sudo timedatectl set-timezone America/Buenos_Aires  # TZ alias
# perl -MDate::Manip -le 'print("System local time (set to ".Date_TimeZone.") with perl(Date::Manip) version ".$Date::Manip::VERSION.": ".UnixDate("now","%Y-%m-%d %H:%M:%S %Z"));'
System local time (set to america/argentina/buenos_aires) with perl(Date::Manip) version 6.91: 2023-02-23 14:21:56 -03
~~~